### PR TITLE
Replace riscv-gcc with the kernel src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 work/
 toolchain/
 log
+linux/

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "buildroot"]
 	path = buildroot
 	url = https://github.com/buildroot/buildroot.git
-[submodule "linux"]
-	path = linux
-	url = git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
 [submodule "riscv-pk"]
 	path = riscv-pk
 	url = https://github.com/riscv/riscv-pk

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ PATH := $(RISCV)/bin:$(PATH)
 ISA ?= rv64imafdc
 ABI ?= lp64d
 
+LINUX_VER ?= 5.8.1
+LINUX_MIRROR ?= https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-$(LINUX_VER).tar.gz
+
 srcdir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 srcdir := $(srcdir:/=)
 confdir := $(srcdir)/conf
@@ -55,7 +58,11 @@ $(RISCV)/bin/$(target_linux)-gcc:
 	$(error The RISCV environment variable was set, but is not pointing at a toolchain install tree)
 endif
 
-$(toolchain_dest)/bin/$(target_linux)-gcc: $(toolchain_srcdir)
+$(linux_srcdir):
+	curl $(LINUX_MIRROR) | tar zxf -
+	mv linux-$(LINUX_VER) linux
+
+$(toolchain_dest)/bin/$(target_linux)-gcc: $(linux_srcdir) $(toolchain_srcdir)
 	mkdir -p $(toolchain_wrkdir)
 	$(MAKE) -C $(linux_srcdir) O=$(toolchain_wrkdir) ARCH=riscv INSTALL_HDR_PATH=$(abspath $(toolchain_srcdir)/linux-headers) headers_install
 	cd $(toolchain_wrkdir); $(toolchain_srcdir)/configure \

--- a/update-submodule.sh
+++ b/update-submodule.sh
@@ -2,9 +2,12 @@
 
 NJOB=4
 
-git submodule update --init --jobs $NJOB buildroot riscv-gnu-toolchain linux riscv-pk riscv-isa-sim
+git submodule update --init --jobs $NJOB buildroot riscv-gnu-toolchain riscv-pk riscv-isa-sim
 
 cd riscv-gnu-toolchain
 git submodule update --init --jobs $NJOB riscv-binutils riscv-gcc riscv-glibc riscv-newlib riscv-gdb
 cd -
+
+curl https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-5.8.1.tar.gz | tar xzf -
+mv linux-5.8.1 linux
 


### PR DESCRIPTION
Cloning the whole linux repo requires downloading a repo nearly 2GB while we do not really need to keep the whole commit history. To remove this requirement, I have replace it with a Makefile step which will download the source code from kernel mirror (only 170MB).

Users are still possible to set the version of Linux by revise the Makefile or just predownload a different version to the linux directory.