### PR TITLE
Support FPGA flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ PATH := $(RISCV)/bin:$(PATH)
 ISA ?= rv64imafdc_zifencei_zicsr
 ABI ?= lp64d
 BL ?= bbl
+BOARD ?= False
+
+ifeq ($(BOARD),False)
+	DTS=$(abspath conf/spike.dts)
+else
+	DTS=$(abspath conf/starship.dts)
+endif
 
 topdir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 topdir := $(topdir:/=)
@@ -142,7 +149,7 @@ $(bbl): $(pk_srcdir) $(vmlinux_stripped)
 		--with-payload=$(vmlinux_stripped) \
 		--enable-logo \
 		--with-logo=$(abspath conf/logo.txt) \
-		--with-dts=$(abspath conf/spike.dts)
+		--with-dts=$(DTS)
 	CFLAGS="-mabi=$(ABI) -march=$(ISA)" $(MAKE) -C $(pk_wrkdir)
 
 
@@ -212,3 +219,8 @@ sim: $(bbl) $(spike)
 qemu: $(qemu) $(bbl)
 	$(qemu) -nographic -machine virt -cpu rv64,sv57=on -m 2048M -bios $(bbl)
 endif
+
+SD_CARD ?= /dev/sdb
+.PHONY: make_sd
+make_sd: $(bbl)
+	sudo dd if=$(bbl).bin of=$(SD_CARD)1 bs=4096

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,7 @@ ISA ?= rv64imafdc_zifencei_zicsr
 ABI ?= lp64d
 BL ?= bbl
 BOARD ?= False
-
-ifeq ($(BOARD),False)
-	DTS=$(abspath conf/spike.dts)
-else
-	DTS=$(abspath conf/starship.dts)
-endif
+DTS ?= $(abspath conf/spike.dts)
 
 topdir := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 topdir := $(topdir:/=)
@@ -219,6 +214,10 @@ sim: $(bbl) $(spike)
 qemu: $(qemu) $(bbl)
 	$(qemu) -nographic -machine virt -cpu rv64,sv57=on -m 2048M -bios $(bbl)
 endif
+
+.PHONY: board
+board: DTS=$(abspath conf/starship.dts)
+board: $(bbl)
 
 SD_CARD ?= /dev/sdb
 .PHONY: make_sd

--- a/conf/starship.dts
+++ b/conf/starship.dts
@@ -1,0 +1,121 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <1>;
+	#size-cells = <1>;
+	compatible = "zjv,starship-dev";
+	model = "zjv,starship";
+	L18: aliases {
+		serial0 = &L10;
+	};
+	L13: chosen {
+		bootargs = "nokaslr noinitrd console=hvc0 root=/dev/mmcblk0p2 rootwait rw";
+	};
+	L17: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <1000000>;
+		L4: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <16384>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			hardware-exec-breakpoint-count = <1>;
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <16384>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L12>;
+			reg = <0x0>;
+			riscv,isa = "rv64imafdc";
+			riscv,pmpgranularity = <4>;
+			riscv,pmpregions = <8>;
+			status = "okay";
+			timebase-frequency = <1000000>;
+			tlb-split;
+			L2: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L12: memory@80000000 {
+		device_type = "memory";
+		reg = <0x80000000 0x40000000>;
+	};
+	L16: soc {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "zjv,starship-soc", "simple-bus";
+		ranges;
+		L6: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L2 3 &L2 7>;
+			reg = <0x2000000 0x10000>;
+			reg-names = "control";
+		};
+		L1: error-device@3000 {
+			compatible = "sifive,error0";
+			reg = <0x3000 0x1000>;
+		};
+		L5: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L2 11 &L2 9>;
+			reg = <0xc000000 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <3>;
+			riscv,ndev = <2>;
+		};
+		L8: rom@10000 {
+			compatible = "sifive,rom0";
+			reg = <0x10000 0x10000>;
+			reg-names = "mem";
+		};
+		L9: rom@20000 {
+			compatible = "sifive,maskrom0";
+			reg = <0x20000 0x2000>;
+			reg-names = "mem";
+		};
+		L10: serial@64000000 {
+			clocks = <&L0>;
+			compatible = "sifive,uart0";
+			interrupt-parent = <&L5>;
+			interrupts = <1>;
+			reg = <0x64000000 0x1000>;
+			reg-names = "control";
+		};
+		L11: spi@64001000 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			clocks = <&L0>;
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L5>;
+			interrupts = <2>;
+			reg = <0x64001000 0x1000>;
+			reg-names = "control";
+			L14: mmc@0 {
+				compatible = "mmc-spi-slot";
+				disable-wp;
+				reg = <0x0>;
+				spi-max-frequency = <20000000>;
+				voltage-ranges = <3300 3300>;
+			};
+		};
+		L0: subsystem_pbus_clock {
+			#clock-cells = <0>;
+			clock-frequency = <100000000>;
+			clock-output-names = "subsystem_pbus_clock";
+			compatible = "fixed-clock";
+		};
+	};
+};
+

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -33,7 +33,7 @@ root="$(dirname "$(readlink -f "$0")")"
 NJOB=4
 
 root_repo_list=${ROOT_LIST:-"buildroot riscv-gnu-toolchain riscv-pk linux riscv-isa-sim"}
-toolchain_repo_list=${TOOLCHAIN_LIST:-"riscv-binutils riscv-gcc riscv-glibc riscv-newlib riscv-gdb"}
+toolchain_repo_list=${TOOLCHAIN_LIST:-"binutils gcc glibc newlib gdb"}
 
 fetch_repo "$root/repo" "$root_repo_list" "--jobs $NJOB"
 fetch_repo "$root/repo/riscv-gnu-toolchain" "$toolchain_repo_list" "--recursive --jobs $NJOB"


### PR DESCRIPTION
1.repair quickstart.sh to pull the submodule in riscv-gnu-toolchain
2.add make_sd target in Makefile so that we can make sd card quickly
3.add the starship.dts and we can use BOARD variable to choose simulation with spike.dts or FPGA with starship.dts